### PR TITLE
feat: Add Swagger documentation link and Makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,27 @@ help:
 	@echo "  make clean-all              - Para tudo, limpa DB, Gradle e contêineres."
 	@echo "  make force-remove-db-container - Força a remoção do contêiner 'pokedex-db'."
 	@echo "  make deep-clean-gradle      - Limpa caches e artefatos do Gradle."
+	@echo ""
+	@echo "  make open-swagger           - Abre a documentação Swagger no navegador."
 	@echo "==================================================================="
+
+# ==============================================================================
+# Documentação da API (Swagger)
+# ==============================================================================
+SWAGGER_URL = http://localhost:8080/swagger-ui/index.html
+
+open-swagger:
+	@echo "--- Abrindo Swagger UI no navegador: $(SWAGGER_URL) ---"
+	@if command -v xdg-open > /dev/null; then \
+		xdg-open $(SWAGGER_URL); \
+	elif command -v open > /dev/null; then \
+		open $(SWAGGER_URL); \
+	elif command -v start > /dev/null; then \
+		start $(SWAGGER_URL); \
+	else \
+		echo "Não foi possível detectar um comando para abrir URLs automaticamente."; \
+		echo "Por favor, abra manualmente: $(SWAGGER_URL)"; \
+	fi
 
 # ==============================================================================
 # Banco de Dados

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ make
 ```
 ---
 
+## Documentação da API (Swagger)
+
+A documentação interativa da API do Pokedex BFF está disponível através do Swagger UI. Você pode explorar os endpoints, visualizar os modelos de dados e até mesmo testar as chamadas diretamente pelo navegador.
+
+*   **Link para o Swagger UI:** [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+
+Certifique-se de que a aplicação Pokedex BFF esteja em execução para acessar a documentação.
+
+---
+
 # Arquitetura do Sistema
 
 - [Arquitetura](doc/ARCHITECTURE.md)


### PR DESCRIPTION
- Added a new section to README.md with a link to the Swagger UI.
- Added a new `open-swagger` command to the Makefile to open the Swagger UI in the default browser.