### PR TITLE
feat: Reestrutura a documentação do projeto

### DIFF
--- a/doc/API_DOCUMENTATION.md
+++ b/doc/API_DOCUMENTATION.md
@@ -1,0 +1,7 @@
+# Documentação da API (Swagger)
+
+A documentação interativa da API do Pokedex BFF está disponível através do Swagger UI. Você pode explorar os endpoints, visualizar os modelos de dados e até mesmo testar as chamadas diretamente pelo navegador.
+
+*   **Link para o Swagger UI:** [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+
+Certifique-se de que a aplicação Pokedex BFF esteja em execução para acessar a documentação.

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -1,0 +1,63 @@
+# Como Começar
+
+Siga estas instruções para configurar e executar o Pokedex BFF em seu ambiente de desenvolvimento local.
+
+### Pré-requisitos
+
+Certifique-se de ter as seguintes ferramentas instaladas:
+* [Java Development Kit (JDK) 21](https://www.oracle.com/java/technologies/downloads/)
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/) (inclui Docker e Docker Compose)
+* **GNU Make** (ou `make` no seu sistema, geralmente pré-instalado em sistemas Unix/Linux/macOS; para Windows, você pode usar WSL ou ferramentas como Chocolatey para instalar `make`).
+
+### Instalação e Configuração Rápida
+
+1.  **Clone o Repositório:**
+    ```bash
+    git clone [https://github.com/seu-usuario/pokedex-bff.git](https://github.com/seu-usuario/pokedex-bff.git) # Substitua 'seu-usuario' e 'pokedex-bff'
+    cd pokedex-bff
+    ```
+
+2.  **Configuração do Ambiente e Início (Recomendado):**
+    * Para uma configuração rápida e completa do ambiente de desenvolvimento (iniciar DB e carregar dados):
+        ```bash
+        make dev-setup
+        ```
+      Este comando cuidará de:
+        1.  Iniciar o contêiner PostgreSQL via Docker Compose.
+        2.  Aguardar o banco de dados estar pronto.
+        3.  Iniciar o BFF, que por sua vez executará as migrações (se configuradas para rodar no `bootRun` do perfil `dev`) e populará o DB com os dados dos arquivos jsons na pasta resource.
+
+### Executando Apenas o Servidor (se o DB já estiver configurado)
+
+Se o banco de dados já estiver rodando e populado, você pode iniciar apenas a aplicação BFF:
+
+```bash
+make run-bff
+```
+
+### Caso precise ver as opções do comando make
+Rode o comando abaixo:
+```bash
+make
+```
+```bach
+===================================================================
+                 Comandos do Makefile para Pokedex BFF
+===================================================================
+  make help                   - Exibe esta mensagem de ajuda.
+
+  make dev-setup              - Configura e inicia o ambiente (Linux/macOS).
+  make dev-setup-for-windows - Configura e inicia o ambiente (Git Bash/WSL no Windows).
+
+  make start-db               - Inicia o banco PostgreSQL com Docker Compose.
+  make stop-db                - Para o contêiner do banco.
+  make clean-db               - Remove o banco e os volumes (apaga os dados!).
+  make load-data              - Executa o BFF e carrega os dados JSON.
+  make run-bff                - Executa o BFF sem importar dados.
+  make clean-bff              - Executa './gradlew clean'.
+
+  make clean-all              - Para tudo, limpa DB, Gradle e contêineres.
+  make force-remove-db-container - Força a remoção do contêiner 'pokedex-db'.
+  make deep-clean-gradle      - Limpa caches e artefatos do Gradle.
+===================================================================
+```

--- a/doc/TECHNOLOGIES.md
+++ b/doc/TECHNOLOGIES.md
@@ -1,0 +1,29 @@
+# Tecnologias e Softwares Utilizados
+
+Este projeto utiliza uma pilha de tecnologias modernas e ferramentas práticas para garantir eficiência, organização e facilidade de desenvolvimento.
+
+### 🛠️ Tecnologias
+
+<p><img src="icons/springboot.png" width="24" height="24" /> <strong>Spring Boot</strong> — Framework robusto para backend em Java/Kotlin. <a href="https://spring.io/projects/spring-boot">Documentação</a></p>
+
+<p><img src="icons/java.png" width="24" height="24" /> <strong>Kotlin & JDK 21</strong> — Linguagem principal na JVM, usando JDK 21. <a href="https://www.oracle.com/java/technologies/downloads/">Download JDK 21</a></p>
+
+<p><img src="icons/springdata.png" width="24" height="24" /> <strong>Spring Data JPA</strong> — Interação com banco relacional de forma orientada a objetos. <a href="https://spring.io/projects/spring-data-jpa">Documentação</a></p>
+
+<p><img src="icons/gradle.png" width="24" height="24" /> <strong>Gradle</strong> — Automação de build e gerenciamento de dependências. <a href="https://gradle.org/">Documentação</a></p>
+
+<p><img src="icons/postgresql.png" width="24" height="24" /> <strong>PostgreSQL</strong> — Banco de dados relacional robusto e extensível. <a href="https://www.postgresql.org/">Site Oficial</a></p>
+
+<p>⚙️ <strong>Apache Commons CSV</strong> — Biblioteca para leitura e processamento de arquivos CSV. <a href="https://commons.apache.org/proper/commons-csv/">Documentação</a></p>
+
+### 💻 Softwares e Ferramentas
+
+<p><img src="icons/intellij.png" width="24" height="24" /> <strong>IntelliJ IDEA</strong> — IDE recomendada para desenvolvimento em Kotlin e Spring Boot. <a href="https://www.jetbrains.com/idea/">Download</a></p>
+
+<p><img src="icons/docker.png" width="24" height="24" /> <strong>Docker & Docker Compose</strong> — Criação e orquestração de contêineres para ambientes isolados. <a href="https://www.docker.com/products/docker-desktop/">Download</a></p>
+
+<p><img src="icons/beekeeperstudio.png" width="24" height="24" /> <strong>Beekeeper Studio</strong> — Cliente SQL visual para gerenciar e consultar o banco PostgreSQL. <a href="https://www.beekeeperstudio.io/">Download</a></p>
+
+<p><img src="icons/bruno.png" width="24" height="24" /> <strong>Bruno</strong> — Cliente para testar e documentar APIs REST de forma intuitiva. <a href="https://www.usebruno.com/">Site Oficial</a></p>
+
+Essas tecnologias e ferramentas tornam o desenvolvimento e a manutenção do **Pokedex BFF** mais produtivos, organizados e escaláveis.


### PR DESCRIPTION
- Move as seções de Tecnologias, Como Começar, Documentação da API e Arquitetura para arquivos Markdown separados dentro do diretório `doc/`.
- Simplifica o `README.md` para ser um ponto de entrada mais conciso, com links para a documentação detalhada.
- Renomeia a coleção do Postman para `POSTMAN_COLLECTION.json` para refletir um padrão de nomenclatura mais claro e em maiúsculas.
- Adiciona novos arquivos de documentação em maiúsculas e em inglês, conforme solicitado.

Com essa mudança, a documentação se torna mais organizada e modular, facilitando a navegação e a manutenção das informações do projeto.